### PR TITLE
Compile fix for Windows with C++11

### DIFF
--- a/include/boost/sync/detail/condition_variables/basic_condition_variable_windows.hpp
+++ b/include/boost/sync/detail/condition_variables/basic_condition_variable_windows.hpp
@@ -138,7 +138,7 @@ private:
     long m_total_waiter_count;
 
 public:
-    BOOST_CONSTEXPR basic_condition_variable() BOOST_NOEXCEPT : m_notify_state(NULL), m_wait_state(NULL), m_total_waiter_count(0)
+    basic_condition_variable() BOOST_NOEXCEPT : m_notify_state(NULL), m_wait_state(NULL), m_total_waiter_count(0)
     {
     }
 

--- a/include/boost/sync/detail/condition_variables/condition_variable_windows.hpp
+++ b/include/boost/sync/detail/condition_variables/condition_variable_windows.hpp
@@ -45,11 +45,7 @@ private:
     sync::detail::windows::basic_condition_variable m_cond;
 
 public:
-#if !defined(BOOST_NO_CXX11_CONSTEXPR)
-#define BOOST_SYNC_DEFINES_CONDITION_VARIABLE_CONSTEXPR_CONSTRUCTOR
-#endif
-
-    BOOST_CONSTEXPR condition_variable() BOOST_NOEXCEPT : m_cond()
+    condition_variable() BOOST_NOEXCEPT : m_cond()
     {
     }
 

--- a/include/boost/sync/detail/mutexes/mutex_windows.hpp
+++ b/include/boost/sync/detail/mutexes/mutex_windows.hpp
@@ -40,11 +40,7 @@ private:
     sync::detail::windows::basic_mutex m_mutex;
 
 public:
-#if !defined(BOOST_NO_CXX11_CONSTEXPR)
-#define BOOST_SYNC_DEFINES_MUTEX_CONSTEXPR_CONSTRUCTOR
-#endif
-
-    BOOST_CONSTEXPR mutex() BOOST_NOEXCEPT : m_mutex() {}
+    mutex() BOOST_NOEXCEPT : m_mutex() {}
 
     void lock()
     {


### PR DESCRIPTION
As detail::windows::basic_mutex's destructor is not trivial, mutex's
constructor cannot be constexpr under Windows. This resulted in compilation
errors with clang-cl and MSVC 14 RC.
