### PR TITLE
fix 64 to 32 bit conversion warning with clang on MacOS

### DIFF
--- a/include/boost/sync/detail/time_units.hpp
+++ b/include/boost/sync/detail/time_units.hpp
@@ -172,7 +172,7 @@ public:
     //! Creates time point from duration since 1970-Jan-01
     explicit system_time_point(system_duration dur) BOOST_NOEXCEPT
     {
-        m_value.tv_sec = dur.get() / subsecond_fraction;
+        m_value.tv_sec = static_cast<decltype(native_type::tv_sec)>(dur.get() / subsecond_fraction);
         m_value.tv_nsec = dur.get() % subsecond_fraction;
     }
 
@@ -202,7 +202,7 @@ public:
             tv_nsec += subsecond_fraction;
             --m_value.tv_sec;
         }
-        m_value.tv_nsec = tv_nsec;
+        m_value.tv_nsec = static_cast<decltype(native_type::tv_sec)>(tv_nsec);
         m_value.tv_sec += nsec / system_duration::subsecond_fraction;
 
         return *this;

--- a/include/boost/sync/detail/time_units.hpp
+++ b/include/boost/sync/detail/time_units.hpp
@@ -172,7 +172,7 @@ public:
     //! Creates time point from duration since 1970-Jan-01
     explicit system_time_point(system_duration dur) BOOST_NOEXCEPT
     {
-        m_value.tv_sec = static_cast<decltype(native_type::tv_sec)>(dur.get() / subsecond_fraction);
+        m_value.tv_sec = static_cast<::time_t>(dur.get() / subsecond_fraction);
         m_value.tv_nsec = dur.get() % subsecond_fraction;
     }
 
@@ -202,7 +202,7 @@ public:
             tv_nsec += subsecond_fraction;
             --m_value.tv_sec;
         }
-        m_value.tv_nsec = static_cast<decltype(native_type::tv_sec)>(tv_nsec);
+        m_value.tv_nsec = static_cast<long>(tv_nsec);
         m_value.tv_sec += nsec / system_duration::subsecond_fraction;
 
         return *this;


### PR DESCRIPTION
This patch fixes two 64 to 32 bit conversion warnings in the `system_time_point` class with `clang` on MacOS (`::time spec::tv_sec` is 32 bit on MacOS).

The fix is using `static_cast<decltype(native_type::tv_sec)>` which should be OK on other platforms, too.

Edit: changed casts to use standardized member types of `timespec` (http://en.cppreference.com/w/c/chrono/timespec), this ensures compatibility to C++03.
