### PR TITLE
Remove use of unintended digraph.

### DIFF
--- a/include/boost/sync/detail/time_units.hpp
+++ b/include/boost/sync/detail/time_units.hpp
@@ -172,7 +172,7 @@ public:
     //! Creates time point from duration since 1970-Jan-01
     explicit system_time_point(system_duration dur) BOOST_NOEXCEPT
     {
-        m_value.tv_sec = static_cast<::time_t>(dur.get() / subsecond_fraction);
+        m_value.tv_sec = static_cast< ::time_t>(dur.get() / subsecond_fraction);
         m_value.tv_nsec = dur.get() % subsecond_fraction;
     }
 


### PR DESCRIPTION
Some compilers will replace '<:' with '['.

Tested under gcc 5.4.0 with gnu++98 mode on cygwin64.