### PR TITLE
Try to fix doc build

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -207,15 +207,8 @@ boostbook sync
         <format>pdf:<xsl:param>img.src.path=$(images_location)/
     ;
 
-alias boostdoc : sync
-    : : : <implicit-dependency>sync ;
-
 ###############################################################################
-alias boostdoc
-    : sync
-    :
-    :
-    : ;
+alias boostdoc ;
 explicit boostdoc ;
-alias boostrelease ;
+alias boostrelease : sync ;
 explicit boostrelease ;


### PR DESCRIPTION
The duplicate 'boostdoc' targets were confusing the documentation build.
As your index.html redirects to doc/html/index.html, this should set it
up to build there.