### PR TITLE
semaphores: fix race condition in wait_until

### DIFF
--- a/include/boost/sync/detail/semaphore/semaphore_dispatch.hpp
+++ b/include/boost/sync/detail/semaphore/semaphore_dispatch.hpp
@@ -130,12 +130,12 @@ private:
         typedef typename time_point::clock clock;
         typedef typename time_point::duration duration;
         time_point now = clock::now();
-        while (now < t.get())
+        do
         {
             if (priv_timed_wait(sync::detail::time_traits< duration >::to_sync_unit(t.get() - now)))
                 return true;
             now = clock::now();
-        }
+        } while (now < t.get());
         return false;
     }
 

--- a/include/boost/sync/detail/semaphore/semaphore_posix.hpp
+++ b/include/boost/sync/detail/semaphore/semaphore_posix.hpp
@@ -173,12 +173,12 @@ private:
         typedef typename time_point::clock clock;
         typedef typename time_point::duration duration;
         time_point now = clock::now();
-        while (now < t.get())
+        do
         {
             if (priv_timed_wait(sync::detail::time_traits< duration >::to_sync_unit(t.get() - now)))
                 return true;
             now = clock::now();
-        }
+        } while (now < t.get());
         return false;
     }
 

--- a/test/run/semaphore_test.cpp
+++ b/test/run/semaphore_test.cpp
@@ -220,4 +220,20 @@ BOOST_AUTO_TEST_CASE(test_semaphore_timed_wait)
         // guessing!
         BOOST_REQUIRE( (end - start) < posix_time::milliseconds(100) );
     }
+
+    {
+        // timed wait after timeout
+        boost::sync::semaphore sema;
+
+        using namespace boost::chrono;
+
+        BOOST_AUTO(start, steady_clock::now());
+        BOOST_AUTO(timeout, start + milliseconds(100));
+
+        boost::this_thread::sleep_for(milliseconds(500));
+
+        sema.post();
+
+        BOOST_REQUIRE(sema.wait_until(timeout));
+    }
 }


### PR DESCRIPTION
wait_until used to return `false` in case the semaphore was posted, but
the timeout has already exceeded at the time of the call