### PR TITLE
fix boost deprecated header warnings

### DIFF
--- a/include/boost/sync/condition_variables/cv_status.hpp
+++ b/include/boost/sync/condition_variables/cv_status.hpp
@@ -14,7 +14,7 @@
 #ifndef BOOST_SYNC_CONDITION_VARIABLES_CV_STATUS_HPP_INCLUDED_
 #define BOOST_SYNC_CONDITION_VARIABLES_CV_STATUS_HPP_INCLUDED_
 
-#include <boost/detail/scoped_enum_emulation.hpp>
+#include <boost/core/scoped_enum.hpp>
 #include <boost/sync/detail/config.hpp>
 #include <boost/sync/detail/header.hpp>
 

--- a/test/run/condition_variable.cpp
+++ b/test/run/condition_variable.cpp
@@ -7,7 +7,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/config.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/sync/locks/unique_lock.hpp>
 #include <boost/sync/mutexes/mutex.hpp>
 #include <boost/sync/condition_variables/condition_variable.hpp>

--- a/test/run/event_test.cpp
+++ b/test/run/event_test.cpp
@@ -5,7 +5,7 @@
 
 #include <boost/core/lightweight_test.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/chrono.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/sync/events.hpp>

--- a/test/run/mutex_test.cpp
+++ b/test/run/mutex_test.cpp
@@ -6,7 +6,7 @@
 
 #include <boost/core/lightweight_test.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/sync/mutexes.hpp>
 #include <boost/sync/locks.hpp>

--- a/test/run/semaphore_test.cpp
+++ b/test/run/semaphore_test.cpp
@@ -5,7 +5,7 @@
 
 #include <boost/core/lightweight_test.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/chrono.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/thread/thread_time.hpp>


### PR DESCRIPTION
`boost` deprecated some headers in recent versions, this PR replaces them by the recommended ones.

This silences a number of warnings when building `boost.sync`.